### PR TITLE
setstate correction

### DIFF
--- a/lib/homePage.dart
+++ b/lib/homePage.dart
@@ -116,7 +116,7 @@ class HomePageView extends State<HomePage> with SingleTickerProviderStateMixin {
       if (_counter > 0) {
         _bpm = _bpm / _counter;
         setState(() {
-          _bpm = (1 - _alpha) * _bpm + _alpha * _bpm;
+          this._bpm = ((1 - _alpha) * _bpm + _alpha * _bpm).toInt();
         });
       }
       await Future.delayed(


### PR DESCRIPTION
Fix #1 
This issue was also pointed by a guy in the comment section of your blog@medium.
Description: Estimated BP is not updated.
Note: `(_bpm > 30 && _bpm < 150)` condition has been removed while recording the video
Before PR: https://www.loom.com/share/1668dc52284246d98cbe9fe3a8b125f6
After PR: https://www.loom.com/share/8ceef11c67954f1983b6558740935691